### PR TITLE
Gather facts for all hosts

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,4 +1,8 @@
 ---
+- gather_facts: True 
+  hosts: all
+  user: root
+
 - name: Main server configuration
   hosts: central
   user: root


### PR DESCRIPTION
Gather facts had not run against all the hosts in the group when running the multi node deployment and the videobridge server is different than the central server.

I fixed this by adding the `gather_facts` explicitly for all hosts at the beginning of the play and should fix the issue https://github.com/udima-university/ansible-jitsi-meet/issues/10 